### PR TITLE
feat(performance): limit select fields in sitemap API

### DIFF
--- a/src/CaptainWatch.Api.Domain/Bo/Movies/Result/MovieBo.cs
+++ b/src/CaptainWatch.Api.Domain/Bo/Movies/Result/MovieBo.cs
@@ -4,6 +4,5 @@
     {
         public int Id { get; set; }
         public string Title { get; set; } = string.Empty;
-        public string OriginalTitle { get; set; } = string.Empty;
     }
 }

--- a/src/CaptainWatch.Api.Domain/Bo/Series/Result/SerieBo.cs
+++ b/src/CaptainWatch.Api.Domain/Bo/Series/Result/SerieBo.cs
@@ -4,6 +4,5 @@
     {
         public int Id { get; set; }
         public string Title { get; set; } = string.Empty;
-        public string OriginalTitle { get; set; } = string.Empty;
     }
 }

--- a/src/CaptainWatch.Api.Repository.Db/Extensions/MovieExtensions.cs
+++ b/src/CaptainWatch.Api.Repository.Db/Extensions/MovieExtensions.cs
@@ -30,7 +30,6 @@ namespace CaptainWatch.Api.Repository.Db.Extensions
             {
                 Id = s.Id,
                 Title = s.Title,
-                OriginalTitle = s.OriginalTitle,
             };
         }
     }

--- a/src/CaptainWatch.Api.Repository.Db/Extensions/SerieExtensions.cs
+++ b/src/CaptainWatch.Api.Repository.Db/Extensions/SerieExtensions.cs
@@ -17,7 +17,6 @@ namespace CaptainWatch.Api.Repository.Db.Extensions
             {
                 Id = s.Id,
                 Title = s.Name,
-                OriginalTitle = s.OriginalName,
             };
         }
     }

--- a/src/CaptainWatch.Api.Repository.Db/Movies/MovieRepo.cs
+++ b/src/CaptainWatch.Api.Repository.Db/Movies/MovieRepo.cs
@@ -28,8 +28,12 @@ namespace CaptainWatch.Api.Repository.Db.Movies
 
         public async Task<IEnumerable<MovieBo>> GetMoviesWithPositiveSiteScore()
         {
-            var movies = await _dbContext.Movie.Where(_ => _.SiteScore > 0).ToListAsync();
-            return movies.ToBo();
+            var movies = await _dbContext.Movie.Where(_ => _.SiteScore > 0).Select(_ => new MovieBo
+            {
+                Id = _.Id,
+                Title = _.Title
+            }).ToListAsync();
+            return movies;
         }
     }
 }

--- a/src/CaptainWatch.Api.Repository.Db/Series/SerieRepo.cs
+++ b/src/CaptainWatch.Api.Repository.Db/Series/SerieRepo.cs
@@ -1,7 +1,6 @@
 ﻿using CaptainWatch.Api.Domain.Bo.Series.Result;
 using CaptainWatch.Api.Domain.Interface.Repository;
 using CaptainWatch.Api.Repository.Db.EntityFramework.Objects;
-using CaptainWatch.Api.Repository.Db.Extensions;
 using Microsoft.EntityFrameworkCore;
 
 namespace CaptainWatch.Api.Repository.Db.Series
@@ -17,8 +16,12 @@ namespace CaptainWatch.Api.Repository.Db.Series
 
         public async Task<IEnumerable<SerieBo>> GetSeriesWithPositiveSiteScore()
         {
-            var series = await _dbContext.Tv.Where(_ => _.SiteScore > 0).ToListAsync();
-            return series.ToBo();
+            var series = await _dbContext.Tv.Where(_ => _.SiteScore > 0).Select(_ => new SerieBo
+            {
+                Id = _.Id,
+                Title = _.Name
+            }).ToListAsync();
+            return series;
         }
     }
 }

--- a/src/CaptainWatch.Api.Services/Sitemaps/SitemapServiceRead.cs
+++ b/src/CaptainWatch.Api.Services/Sitemaps/SitemapServiceRead.cs
@@ -25,7 +25,7 @@ namespace CaptainWatch.Api.Services.Sitemaps
 
             var result = movies.Select(movie => new MovieSitemapBo
             {
-                Title = movie.Title ?? movie.OriginalTitle,
+                Title = movie.Title,
                 Id = movie.Id
             }).ToList();
 
@@ -38,7 +38,7 @@ namespace CaptainWatch.Api.Services.Sitemaps
 
             var result = series.Select(serie => new SerieSitemapBo
             {
-                Title = serie.Title ?? serie.OriginalTitle,
+                Title = serie.Title,
                 Id = serie.Id
             }).ToList();
 

--- a/src/CaptainWatch.Api/Program.cs
+++ b/src/CaptainWatch.Api/Program.cs
@@ -40,7 +40,7 @@ builder.Services.AddSwaggerGen(options =>
         }
     });
     options.CustomOperationIds(e => $"{e.ActionDescriptor.RouteValues["controller"]}_{e.ActionDescriptor.RouteValues["action"]}");
-    options.SwaggerDoc("v1", new OpenApiInfo { Title = "CaptainWatch.Api", Version = "1.0.2" });
+    options.SwaggerDoc("v1", new OpenApiInfo { Title = "CaptainWatch.Api", Version = "1.0.3" });
 });
 
 // Add services to the container.


### PR DESCRIPTION
This PR introduces enhancements to the sitemap API to boost its performance. By limiting the selection of fields to only those necessary