### PR TITLE
chore: migrate from .NET 7 to .NET 9 and update NuGet packages

### DIFF
--- a/src/CaptainWatch.Api.Domain/CaptainWatch.Api.Domain.csproj
+++ b/src/CaptainWatch.Api.Domain/CaptainWatch.Api.Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/CaptainWatch.Api.Repository.Db.EntityFramework/CaptainWatch.Api.Repository.Db.EntityFramework.csproj
+++ b/src/CaptainWatch.Api.Repository.Db.EntityFramework/CaptainWatch.Api.Repository.Db.EntityFramework.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.12" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/CaptainWatch.Api.Repository.Db/CaptainWatch.Api.Repository.Db.csproj
+++ b/src/CaptainWatch.Api.Repository.Db/CaptainWatch.Api.Repository.Db.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/CaptainWatch.Api.Repository.Meilisearch/CaptainWatch.Api.Repository.Meilisearch.csproj
+++ b/src/CaptainWatch.Api.Repository.Meilisearch/CaptainWatch.Api.Repository.Meilisearch.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MeiliSearch" Version="0.15.0" />
+    <PackageReference Include="MeiliSearch" Version="0.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainWatch.Api.Services/CaptainWatch.Api.Services.csproj
+++ b/src/CaptainWatch.Api.Services/CaptainWatch.Api.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
     <PackageReference Include="MailKit" Version="4.10.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
     <PackageReference Include="Mjml.Net" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/CaptainWatch.Api/.config/dotnet-tools.json
+++ b/src/CaptainWatch.Api/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "9.0.2",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/src/CaptainWatch.Api/CaptainWatch.Api.csproj
+++ b/src/CaptainWatch.Api/CaptainWatch.Api.csproj
@@ -1,16 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="ElmahCore" Version="2.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.12" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainWatch.Api/Properties/launchSettings.json
+++ b/src/CaptainWatch.Api/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:1290",
+      "applicationUrl": "http://localhost:1290"
       //"sslPort": 44316
     }
   },


### PR DESCRIPTION
Migrate project from .NET 7 to .NET 9 and update NuGet packages.